### PR TITLE
Change Activty to be in System.Diagnostics

### DIFF
--- a/src/Microsoft.AspNetCore.Ext/Internal/CorrelationMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Ext/Internal/CorrelationMiddleware.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.Activity;
+﻿using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Correlation;

--- a/src/Microsoft.Extensions.Correlation/Internal/HttpDiagnosticListenerObserver.cs
+++ b/src/Microsoft.Extensions.Correlation/Internal/HttpDiagnosticListenerObserver.cs
@@ -5,7 +5,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Activity;
+using System.Diagnostics;
 using System.Net.Http;
 using System.Reflection;
 

--- a/src/SampleApp/ElasticSearchLogger.cs
+++ b/src/SampleApp/ElasticSearchLogger.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.Activity;
+using System.Diagnostics;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using Nest;

--- a/src/SampleApp/MyFilter.cs
+++ b/src/SampleApp/MyFilter.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.Activity;
+﻿using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 

--- a/src/SampleApp/Startup.cs
+++ b/src/SampleApp/Startup.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.Activity;
+﻿using System.Diagnostics;
 using System.Net.Http;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Ext;

--- a/src/System.Diagnostics.Activity/Activity.cs
+++ b/src/System.Diagnostics.Activity/Activity.cs
@@ -2,8 +2,9 @@
 using System.Text;
 using System.Threading;
 
-namespace System.Diagnostics.Activity
+namespace System.Diagnostics
 {
+    // TODO: Consider renameing to DiagnosticActivity 
     public class Activity : IDisposable
     {
         public string OperationName { get; }


### PR DESCRIPTION
There are ambiguities that arise if you name a class the same name as the namespace that contains it.  We should not do this.

I don't think we need a namespace for Activies (there seems to be only one class), so the obvious answer is to simply move Activity to the System.Diagnostic namespace.
